### PR TITLE
Fix faulty replacement of question marks

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -31,7 +31,7 @@ export function cli(args) {
                 try {
                     fs.readFile(localePath, 'utf-8', (err, data) => {
                         data = data.replace(/^#[:] [^\n]+$/gm, '');
-                        data = data.replace(/[\r?\n|\r]+/gm, '\n');
+                        data = data.replace(/[\r\n|\r|\n]+/gm, '\n');
 
                         //checks for first empty line
                         let counter = 0;

--- a/src/cli.js
+++ b/src/cli.js
@@ -31,7 +31,7 @@ export function cli(args) {
                 try {
                     fs.readFile(localePath, 'utf-8', (err, data) => {
                         data = data.replace(/^#[:] [^\n]+$/gm, '');
-                        data = data.replace(/[\r\n|\r|\n]+/gm, '\n');
+                        data = data.replace(/[\r\n]+/gm, '\n');
 
                         //checks for first empty line
                         let counter = 0;


### PR DESCRIPTION
A solution to #2.

I replaced the regex according to this answer on stack overflow:  https://stackoverflow.com/a/20056634

It's arguably a bit too much to even look for `\n` in the regex, but as you did that before I thought I'd keep that functionality if it was needed for some reason. `/[\r\n|\r|\n]+/gm` could probably just be `/[\r\n|\r]+/gm`.